### PR TITLE
Use strict to fix SyntaxError

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,3 +1,5 @@
+'use strict'
+
 process.env.VUE_ENV = 'server'
 const isProd = process.env.NODE_ENV === 'production'
 


### PR DESCRIPTION
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode when running with node v5.3.0